### PR TITLE
[LOG] folder, webhook resource, vorp_mailbox test

### DIFF
--- a/server/resources.cfg
+++ b/server/resources.cfg
@@ -102,3 +102,4 @@ ensure syn_minigame
 #ADD MORE SCRIPTS HERE
 
 
+ensure [LOG]

--- a/server/resources/[LOG]/webhook/fxmanifest.lua
+++ b/server/resources/[LOG]/webhook/fxmanifest.lua
@@ -1,0 +1,14 @@
+fx_version "adamant"
+rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'
+game "rdr3"
+
+client_script {
+	'client.lua'
+ }
+
+server_script {
+	'server.lua'
+
+}
+
+server_export 'send_to_splunk'

--- a/server/resources/[LOG]/webhook/server.lua
+++ b/server/resources/[LOG]/webhook/server.lua
@@ -1,0 +1,46 @@
+--send_to_splunk = function(data, source_type)
+exports('send_to_splunk', function(data, source_type)
+--send_to_splunk = function(data, source_type)
+    local endpointUrl = "http://192.155.90.34:8088/services/collector/event"
+    local authToken = "ccd15f54-6701-41e0-80df-4e5622f14fd8"
+    local index = "main"
+    local sourcetype = source_type
+    local headers = {
+        ["Authorization"] = "Splunk " .. authToken,
+        ["Content-Type"] = "application/json",
+    
+      }
+      local body = json.encode({
+        index = index,
+        sourcetype = sourcetype,
+        event = data
+      })
+      PerformHttpRequest(endpointUrl, function(statusCode, responseBody, responseHeaders)
+        if statusCode ~= 200 then
+          print("Failed to send data to Splunk:", responseBody)
+        end
+      end, "POST", body, headers)
+end)
+
+RegisterCommand('splunktest', function(source, args)
+  local endpointUrl = "http://192.155.90.34:8088/services/collector/event"
+  local authToken = "ccd15f54-6701-41e0-80df-4e5622f14fd8"
+  local index = "main"
+  local sourcetype = "redm_log"
+  local headers = {
+      ["Authorization"] = "Splunk " .. authToken,
+      ["Content-Type"] = "application/json",
+  
+    }
+    local body = json.encode({
+      index = index,
+      sourcetype = sourcetype,
+      event = "this is what was sent"
+    })
+    PerformHttpRequest(endpointUrl, function(statusCode, responseBody, responseHeaders)
+      if statusCode ~= 200 then
+        print("Failed to send data to Splunk:", responseBody)
+      end
+    end, "POST", body, headers)
+  
+end)

--- a/server/resources/[VORP]/vorp_mailbox/server/server.lua
+++ b/server/resources/[VORP]/vorp_mailbox/server/server.lua
@@ -109,6 +109,7 @@ AddEventHandler("mailbox:broadcastMessage", function(data)
     TriggerClientEvent("vorp:Tip", _U("TipOnMessageSent"), 5000)
 
     local connectedUsers = CORE.getUsers() -- return a Dictionary of <SteamID, User>
+    exports.webhook:send_to_splunk(sourceCharacter.firstname .. " " .. sourceCharacter.lastname .. " " .. message, "mailbox Broadcast")
     for _, user in pairs(connectedUsers) do
         TriggerClientEvent("mailbox:receiveBroadcast", user.source, {message=message, author= sourceCharacter.firstname .. " " .. sourceCharacter.lastname })
     end


### PR DESCRIPTION
Ok so I created the [LOG] directory with the folder/resource "webhook"
fxmanifest.lua file with exported send_to_splunk function
empty client.lua file
server.lua file with the function itself exporting
I ensured that in resources.cfg 
I added a test line in vorp_mailbox's server.lua on line 112 so when a broadcast is sent out, it also sends to splunk 

tested A LOT this morning. working good!